### PR TITLE
Switch Webservice paradigm from Jersey to Spring

### DIFF
--- a/provisioner/webservice/provisioner.go
+++ b/provisioner/webservice/provisioner.go
@@ -52,14 +52,11 @@ func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, communicat
 		return err
 	}
 
-	return shell.Provision(ctx, ui, communicator, getCommands(p.config.HomeDir))
+	return shell.Provision(ctx, ui, communicator, getCommands())
 }
 
-func getCommands(homeDir string) []string {
-	return append(
-		getCommandsUpdatingUbuntu(),
-		append(getCommandsInstallingJDK17(), getCommandsInstallingJetty(homeDir)...)...,
-	)
+func getCommands() []string {
+	return append(getCommandsUpdatingUbuntu(), getCommandsInstallingJDK17()...)
 }
 
 func getCommandsUpdatingUbuntu() []string {
@@ -75,21 +72,5 @@ func getCommandsInstallingJDK17() []string {
 		"sudo apt update -y",
 		"sudo apt install openjdk-17-jdk -y",
 		"export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64",
-	}
-}
-
-// Install and configure Jetty (for JDK 17) container
-func getCommandsInstallingJetty(homeDir string) []string {
-	return []string{
-		"export JETTY_VERSION=11.0.15",
-		"wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz",
-		"tar -xzvf jetty-home-$JETTY_VERSION.tar.gz",
-		"rm jetty-home-$JETTY_VERSION.tar.gz",
-		fmt.Sprintf("export JETTY_HOME=%s/jetty-home-$JETTY_VERSION", homeDir),
-		"mkdir jetty-base",
-		"cd jetty-base",
-		"java -jar $JETTY_HOME/start.jar --add-module=annotations,server,http,deploy,servlet,webapp,resources,jsp",
-		fmt.Sprintf("mv %s/ROOT.war webapps/ROOT.war", homeDir),
-		"cd ../",
 	}
 }


### PR DESCRIPTION
[//]: # (Copyright 2024 Paion Data)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

- [This fork](https://github.com/paion-data/packer-plugin-paion-data) switches from [Jersey-Jetty WAR based webservice](https://github.com/QubitPi/packer-plugin-hashicorp-aws/blob/master/provisioner/webservice/provisioner.go) to container-less JAR based Spring Boot webservice so there is no need to install container like Jetty, which is removed from this PR

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
